### PR TITLE
Memory leak bug #1 leading to the "double free or corruption" issue w…

### DIFF
--- a/TuringMachine.cpp
+++ b/TuringMachine.cpp
@@ -50,7 +50,7 @@ bool TuringMachine::clearTape() {
 
 bool TuringMachine::clearRule() {
     for (int i = 0; i < this->ruleMatrixRow; ++i)
-        delete [] this->ruleMatrix;
+        delete [] this->ruleMatrix[i];
     delete [] this->ruleMatrix;
 
     return true;


### PR DESCRIPTION
…hen quitting the application was due to not freeing the actual addresses within the ruleMatrix ('[i]' was forgotten).

Running valgrind (if on linux or maybe OSX) will show if there are any memory leaks. e.g.:
```
valgrind -v --leak-check=full ./a.out TransitionTableExamples/actual_test.txt
```